### PR TITLE
Learn sequential policy with an LSTM. Backprop through time.

### DIFF
--- a/catkin_ws/src/journey/scripts/deep_drone.py
+++ b/catkin_ws/src/journey/scripts/deep_drone.py
@@ -131,10 +131,10 @@ class DeepDronePlanner:
         # Take-off.
         self.takeoff_publisher.publish(EmptyMessage())
 
-        bounds = 2
-        new_goal = (np.random.uniform(size=(3)) - 0.5) * (2 * bounds)
-        new_goal += np.array([0, 0, 1])
-        # new_goal = [-2, 2, 2]
+        # bounds = 2
+        # new_goal = (np.random.uniform(size=(3)) - 0.5) * (2 * bounds)
+        # new_goal += np.array([0, 0, bounds])
+        new_goal = [-2, 2, 1]
         # print("New goal: %s" % new_goal)
         self.goal_pose.position.x = new_goal[0]
         self.goal_pose.position.y = new_goal[1]


### PR DESCRIPTION
Our policy output action is now conditioned on it's state history. This outperforms the standard DDPG approach in practice. This is similar to how [OpenAI transfer method](https://blog.openai.com/generalizing-from-simulation/) where they were not able to generalize well with just a feedforward network.

I had to change how I train since I'm considered the entire state history. Now I need to backprop through time. Now we execute an entire episode, and once we have executed some number of episodes, we collect the batch of trajectories and optimize all the entire set of previous episodes all at once.