### PR TITLE
Increase max episode length

### DIFF
--- a/catkin_ws/src/journey/scripts/deep_drone.py
+++ b/catkin_ws/src/journey/scripts/deep_drone.py
@@ -178,7 +178,7 @@ class DeepDronePlanner:
             env,
             actor_noise,
             logdir=logdir,
-            max_episodes=200,
+            max_episodes=1000,
             max_episode_len=50)
 
 


### PR DESCRIPTION
In the original paper, they trained on 160000 trajectories over 200 epochs of 800 trajectories with 50 steps. We now train for 1000 episodes which gives us a total of 51000 trajectories. I increased this to approach the scale we probably should expect to train for.