### PR TITLE
Train on batches of at least 800 trajectories.

### DIFF
--- a/catkin_ws/src/journey/scripts/ddpg.py
+++ b/catkin_ws/src/journey/scripts/ddpg.py
@@ -151,7 +151,7 @@ class DeepDeterministicPolicyGradients:
             ep_ave_max_q = np.amax(predicted_q_values)
 
             if replay_buffer.size() >= self.minibatch_size:
-                print("Finished epoch. Training minibatch with %s trajectories"
+                print("Finished epoch. Training minibatch with %s trajectories."
                       % replay_buffer.size())
 
                 (s_batch, a_batch, r_batch, t_batch,


### PR DESCRIPTION
Train on a large set of trajectories (800), then clear the trajectory buffer. This helps us not bias toward the initially sampled trajectories because we collect a new set of samples at every training epoch. This helps reduce variance between trajectories because our batch is a large set that we can do stable optimization on.

800 is chosen as the epoch size because it was the size used in the hindsight experience replay paper.