### PR TITLE
Add simulated depth camera to drone model

### DIFF
--- a/catkin_ws/src/journey/launch/journey_simulator.launch
+++ b/catkin_ws/src/journey/launch/journey_simulator.launch
@@ -7,7 +7,7 @@
 
 
   <include file="$(find cvg_sim_gazebo)/launch/spawn_quadrotor.launch" >
-    <arg name="model" value="$(find cvg_sim_gazebo)/urdf/quadrotor_sensors.urdf.xacro"/>
+    <arg name="model" value="$(find journey)/urdf/quadrotor_sensors.urdf.xacro"/>
   </include>
 
   <!-- Launch state estimation module -->

--- a/catkin_ws/src/journey/scripts/deep_drone.py
+++ b/catkin_ws/src/journey/scripts/deep_drone.py
@@ -40,13 +40,12 @@ class DeepDronePlanner:
         rospy.init_node('deep_drone_planner', anonymous=True)
 
         # Inputs.
-        # TODO(kirmani): Query the depth image instead of the RGB image.
-        self.image_subscriber = rospy.Subscriber('/ardrone/front/image_raw',
-                                                 Image, self._OnNewImage)
+        self.depth_subscriber = rospy.Subscriber(
+            '/ardrone/front/depth/image_raw', Image, self._OnNewDepth)
         self.pose_subscriber = rospy.Subscriber('/ardrone/predictedPose',
                                                 filter_state, self._OnNewPose)
         self.pose = Pose()
-        self.image_msg = None
+        self.depth_msg = None
 
         # Actions.
         self.velocity_publisher = rospy.Publisher(
@@ -94,8 +93,8 @@ class DeepDronePlanner:
         self.pose.position.y = round(data.y, 4)
         self.pose.position.z = round(data.z, 4)
 
-    def _OnNewImage(self, image):
-        self.image_msg = image
+    def _OnNewDepth(self, depth):
+        self.depth_msg = depth
 
     def FlyToGoal(self, req):
         self.goal_pose.position.x = self.pose.position.x + req.x

--- a/catkin_ws/src/journey/urdf/quadrotor_sensors.urdf.xacro
+++ b/catkin_ws/src/journey/urdf/quadrotor_sensors.urdf.xacro
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<robot name="quadrotor_hokuyo_utm30lx"
+xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+   
+    <property name="M_PI" value="3.1415926535897931" />
+    
+    <!-- Included URDF Files -->
+    <xacro:include filename="$(find cvg_sim_gazebo)/urdf/quadrotor_base.urdf.xacro" />
+    
+    <!-- Instantiate quadrotor_base_macro once (has no parameters atm) -->
+    <quadrotor_base_macro />
+    
+
+    <!-- Sonar height sensor -->
+    <xacro:include filename="$(find cvg_sim_gazebo)/urdf/sensors/sonar_sensor.urdf.xacro" />
+    <xacro:sonar_sensor name="sonar" parent="base_link" ros_topic="sonar_height" update_rate="10" min_range="0.01" max_range="3.0" field_of_view="${40*M_PI/180}" ray_count="3">
+      <origin xyz="-0.15 0.0 0.0" rpy="0 ${90*M_PI/180} 0"/>
+    </xacro:sonar_sensor>
+
+
+    <!-- Hokuyo UTM-30LX mounted upside down below the quadrotor body 
+    <xacro:include filename="$(find cvg_sim_gazebo)/urdf/sensors/hokuyo_utm30lx.urdf.xacro" />
+    <xacro:hokuyo_utm30lx name="laser0" parent="base_link" ros_topic="scan" update_rate="40" ray_count="1081" min_angle="135" max_angle="-135">
+      <origin xyz="0.0 0.0 0.08" rpy="${M_PI} 0 0"/>
+    </xacro:hokuyo_utm30lx>-->
+    
+    <!-- The following two cameras should be united to one! -->
+    <!-- Forward facing camera -->
+    <xacro:include filename="$(find journey)/urdf/sensors/generic_camera.urdf.xacro" />
+    <xacro:generic_camera name="front" sim_name="ardrone" parent="base_link" update_rate="60" res_x="640" res_y="360" image_format="R8G8B8" hfov="${81*M_PI/180}">
+      <origin xyz="0.21 0.0 0.01" rpy="0 0 0"/>
+    </xacro:generic_camera>
+
+    <!-- Downward facing camera -->
+    <xacro:include filename="$(find journey)/urdf/sensors/generic_camera.urdf.xacro" />
+    <xacro:generic_camera name="bottom" sim_name="ardrone" parent="base_link" update_rate="60" res_x="640" res_y="360" image_format="R8G8B8" hfov="${81*M_PI/180}">
+      <origin xyz="0.15 0.0 0.0" rpy="0 ${M_PI/2} 0"/>
+    </xacro:generic_camera>
+    
+</robot>
+  

--- a/catkin_ws/src/journey/urdf/sensors/generic_camera.urdf.xacro
+++ b/catkin_ws/src/journey/urdf/sensors/generic_camera.urdf.xacro
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+
+<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:xacro="http://ros.org/wiki/xacro"
+  >  
+  
+    <property name="M_PI" value="3.1415926535897931" />
+  
+    <xacro:macro name="generic_camera" params="name sim_name parent *origin update_rate res_x res_y image_format hfov">
+      <joint name="${name}_joint" type="fixed">
+        <insert_block name="origin" />
+        <parent link="${parent}"/>
+        <child link="${name}_link"/>
+      </joint>
+      
+      <link name="${name}_link">
+        <inertial>
+          <mass value="0.001" />
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001" />
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <box size="0.01 0.01 0.01" />
+          </geometry>
+	  <material name="Blue">
+      <color rgba="0.0 0.0 0.8 1"/>
+    </material>
+        </visual>
+        <collision>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <box size="0.01 0.01 0.01" />
+          </geometry>
+        </collision>
+      </link>
+      
+      
+    <joint name="${name}_optical_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}" />
+      <parent link="${name}_link" />
+      <child link="ardrone_base_${name}cam"/>
+    </joint>
+    
+    <link name="ardrone_base_${name}cam">
+      <inertial>
+        <mass value="0.01" />
+        <origin xyz="0 0 0" />
+        <inertia ixx="0.001"  ixy="0.0"  ixz="0.0"
+                 iyy="0.001"  iyz="0.0"
+                 izz="0.001" />
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.001 0.001 0.001" />
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.001 0.001 0.001" />
+        </geometry>
+      </collision>
+    </link>
+    
+    <gazebo reference="${name}_link">
+      <!--
+      <sensor type="camera" name="${name}_camera_sensor">
+        <update_rate>${update_rate}</update_rate>
+        <camera name="head">
+          <horizontal_fov>${hfov}</horizontal_fov>
+          <image>
+            <width>${res_x}</width>
+            <height>${res_y}</height>
+            <format>${image_format}</format>
+          </image>
+
+          <clip>0.01
+	    <near>0.01</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <plugin name="${name}_camera_controller" filename="libgazebo_ros_camera.so">
+	  <cameraName>/${sim_name}/${name}</cameraName>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>${update_rate}</updateRate>
+          <imageTopicName>/${sim_name}/${name}/image_raw</imageTopicName>
+          <cameraInfoTopicName>/${sim_name}/${name}/camera_info</cameraInfoTopicName>
+          <frameName>ardrone_base_${name}cam</frameName>
+        </plugin>
+      </sensor>
+      -->
+      <sensor type="depth" name="${name}_camera_sensor">
+        <update_rate>${update_rate}</update_rate>
+        <camera name="head">
+          <horizontal_fov>${hfov}</horizontal_fov>
+          <image>
+            <width>${res_x}</width>
+            <height>${res_y}</height>
+            <format>${image_format}</format>
+          </image>
+          <clip>0.01
+	          <near>0.01</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <plugin name="${name}_depth_camera_controller" filename="libgazebo_ros_depth_camera.so">
+          <cameraName>/${sim_name}/${name}/depth</cameraName>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>${update_rate}</updateRate>
+          <imageTopicName>/${sim_name}/${name}/image_raw</imageTopicName>
+          <cameraInfoTopicName>/${sim_name}/${name}/camera_info</cameraInfoTopicName>
+          <depthImageTopicName>/${sim_name}/${name}/depth/image_raw</depthImageTopicName>
+          <depthImageInfoTopicName>/${sim_name}/${name}/depth/camera_info</depthImageInfoTopicName>
+          <pointCloudTopicName>/${sim_name}/${name}/depth/points</pointCloudTopicName>
+          <pointCloudCutoff>0.05</pointCloudCutoff>
+          <distortionK1>0</distortionK1>
+          <distortionK2>0</distortionK2>
+          <distortionK3>0</distortionK3>
+          <distortionT1>0</distortionT1>
+          <distortionT2>0</distortionT2>
+          <CxPrime>0</CxPrime>
+          <Cx>0</Cx>
+          <Cy>0</Cy>
+          <focalLength>0</focalLength>
+          <hackBaseline>0</hackBaseline>
+          <!--
+          <depthImageCameraInfoTopicName>camera1_info</depthImageCameraInfoTopicName>
+          <colorImageTopic>/${sim_name}/${name}/rgb/image_color</colorImageTopic>
+          <depthMapTopic>/${sim_name}/${name}/depth_registered/image_rect</depthMapTopic>
+          -->
+          <!--
+          <cameraInfoTopicName>/${sim_name}/${name}/depth/camera_info</cameraInfoTopicName>
+          -->
+          <frameName>ardrone_base_depth_${name}cam</frameName>
+        </plugin>
+      </sensor>
+      <turnGravityOff>true</turnGravityOff>
+      <material>Gazebo/Blue</material>
+    </gazebo>
+    </xacro:macro>
+  </robot>
+  


### PR DESCRIPTION
Query /ardrone/front/depth/image_raw in deep_drone instead of /ardrone/front/image_raw now. Replaced the libgazebo_ros_camera with a libgazebo_ros_depth_camera on the drone gazebo model. Currently not simulating noise. Assuming perfect depth.