### PR TITLE
Add ability to save and load/run models

### DIFF
--- a/catkin_ws/src/journey/scripts/ddpg.py
+++ b/catkin_ws/src/journey/scripts/ddpg.py
@@ -63,6 +63,24 @@ class DeepDeterministicPolicyGradients:
 
         return summary_ops, summary_vars
 
+    def RunModel(self, env, actor_noise, model_dir, num_attempts=1, max_episode_len=50):
+        saver = tf.train.Saver()
+        saver.restore(self.sess, tf.train.latest_checkpoint(model_dir))
+
+        for i in range(num_attempts):
+            (state, goal) = env.Reset()
+            for j in range(max_episode_len):
+                # Added exploration noise.
+                action = self.actor.predict(
+                    np.expand_dims(
+                        np.expand_dims(
+                            np.concatenate([state, goal], axis=-1), axis=0),
+                        axis=0))[0][0] + actor_noise()
+
+                next_state = env.Step(state, action, goal)
+                state = next_state
+
+
     def Train(self,
               env,
               actor_noise,

--- a/catkin_ws/src/journey/scripts/deep_drone.py
+++ b/catkin_ws/src/journey/scripts/deep_drone.py
@@ -248,6 +248,14 @@ class DeepDronePlanner:
         # reward = 1 if terminal else -1
         # return reward
 
+    def RunModel(self, model_name, num_attempts):
+        env = Environment(self.reset, self.step, self.reward)
+        actor_noise = OrnsteinUhlenbeckActionNoise(
+            mu=np.zeros(self.num_actions))
+        modeldir = os.path.join(
+            os.path.dirname(__file__), '../../../learning/deep_drone/' + model_name)
+        self.ddpg.RunModel(env, actor_noise, modeldir, num_attempts=num_attempts)
+
     def Train(self):
         env = Environment(self.reset, self.step, self.reward)
         actor_noise = OrnsteinUhlenbeckActionNoise(
@@ -259,7 +267,13 @@ class DeepDronePlanner:
 
 def main(args):
     deep_drone_planner = DeepDronePlanner()
-    deep_drone_planner.Train()
+    if args.model:
+        attempts = 1
+        if args.num_attempts:
+            attempts = int(args.num_attempts)
+        deep_drone_planner.RunModel(args.model, num_attempts=attempts)
+    else:
+        deep_drone_planner.Train()
 
 
 if __name__ == '__main__':
@@ -272,6 +286,16 @@ if __name__ == '__main__':
             action='store_true',
             default=False,
             help='verbose output')
+        parser.add_argument(
+            '-m',
+            '--model',
+            action='store',
+            help='run specific model')
+        parser.add_argument(
+            '-n',
+            '--num_attempts',
+            action='store',
+            help='number of attempts to run model for')
         args = parser.parse_args()
         #if len(args) < 1:
         #    parser.error ('missing argument')


### PR DESCRIPTION
We can now save all of the variables associated with the trained models. This PR also adds arguments to ``deep_drone`` (``-m`` along with ``-n``) that allow for loading and running a saved model (by loading the parameters of the actor network).