### PR TITLE
Add reward shaping to encourage forward movement

### DIFF
--- a/catkin_ws/src/journey/scripts/deep_drone.py
+++ b/catkin_ws/src/journey/scripts/deep_drone.py
@@ -247,7 +247,7 @@ class DeepDronePlanner:
         distance = np.linalg.norm(position - goal)
         distance_reward = np.exp(-distance)
         forward_reward = action[0]
-        reward_weights = np.array([1.0, 0.1])
+        reward_weights = np.array([1.0, 0.01])
         reward = np.array([distance_reward, forward_reward])
         return np.dot(reward_weights, reward)
 


### PR DESCRIPTION
By giving some small reward for a forward velocity, we incentivize our drone to move forward a little bit. That way we can push our drone to find the goal faster, and to not stay still or move backwards. We can also add some depth reward to encourage distance from objects that would likely be useful to encourage us to avoid the object because we want to keep moving forward, get closer to the goal, and avoid obstacles.

We can add the obstacle avoidance reward shaping factor once we can interpret the depth values.

Also some minor style nits came up when I ran yapf. I'm surprised git pushing didn't autoformat it for you since we have the git hook.