### PR TITLE
Complete land of simulation randomization for hallways.

### DIFF
--- a/catkin_ws/src/journey/scripts/collision_avoidance/simulation_randomization.py
+++ b/catkin_ws/src/journey/scripts/collision_avoidance/simulation_randomization.py
@@ -156,8 +156,7 @@ class SimulationRandomizer:
 
     def spawn_quadrotor(self, tx=0, ty=0, tz=1, roll=0, pitch=0, yaw=0):
         position = (tx, ty, ty)
-        quaternion = transform.transformations.quaternion_from_euler(
-            roll, pitch, yaw)
+        quaternion = tf.transformations.quaternion_from_euler(roll, pitch, yaw)
 
         reset_pose = Pose()
         reset_pose.position.x = position[0]
@@ -219,6 +218,9 @@ class SimulationRandomizer:
 
 def main(args):
     """ Main function. """
+    # Initialize our ROS node.
+    rospy.init_node('simulation_randomization', anonymous=True)
+
     randomize_simulation = SimulationRandomizer()
     randomize_simulation()
 


### PR DESCRIPTION
- The simulator successfully generates hallways of varying widths and surface textures. The drone start position is random along the hallway width.

I got solid progress on this today. I'll hook up this randomized environment generator up to the actual collision training model tomorrow to reset between episodes. It shouldn't be very hard. My laptop still crashes when I train for too long and it's hella slow, but at least I can set up this infrastructure so that when I get back to Austin, I can just train overnight once on these diverse simulation environments, and immediately be able to try it out on the drone without any fancy transfer learning crap.

I'll also retrain it from greyscale images instead of depth images. It'll be harder to train for sure, but we won't have to worry about the RGB-to-depth domain adaptation, and then we can train a model end-to-end.

Here are three papers that explain the rationale of why this (surprisingly) works:
- [CAD2RL: Real Single-Image Flight without a Single Real Image](https://arxiv.org/pdf/1611.04201.pdf)
- [Domain Randomization for Transferring Deep Neural Networks from Simulation to the Real World](https://arxiv.org/pdf/1703.06907.pdf)
- [ Sim2Real View Invariant Visual Servoing by Recurrent Control](https://arxiv.org/pdf/1712.07642.pdf)

In a nutshell: If the model sees enough simulated variation, the real world may look just like the next simulator.

Merry Christmas!