### PR TITLE
Fix exploration rounding bug

### DIFF
--- a/journey/scripts/collision_avoidance/ddpg.py
+++ b/journey/scripts/collision_avoidance/ddpg.py
@@ -177,7 +177,7 @@ class DeepDeterministicPolicyGradients:
             epoch_rewards = []
             total_epoch_avg_max_q = 0.0
 
-            epsilon = epsilon_zero * (1.0 - epoch / num_epochs)
+            epsilon = epsilon_zero * (1.0 - float(epoch) / num_epochs)
             print("Explore with epsilon greedy (epsilon = %.4f)" % epsilon)
 
             for i in range(episodes_in_epoch):


### PR DESCRIPTION
This fucked our training exploration from decreasing. Integer division made this always 0, so we weren't ever decaying our epsilon rate, so our model always took a random move with a 20% chance during training which would have prevented convergence.